### PR TITLE
Fix Double Free Error

### DIFF
--- a/headers/cave.h
+++ b/headers/cave.h
@@ -4,6 +4,7 @@
 #include "builder.h"
 #include "object.h"
 #include "random.h"
+#include <algorithm>
 #include <iostream>
 
 class CaveLevel : public LevelBuilder

--- a/lib/cave.cpp
+++ b/lib/cave.cpp
@@ -30,6 +30,10 @@ void CaveLevel::construct()
     playerLeft = center - playerSpace / 2;
     playerRight = center + playerSpace / 2;
 
+    // Boundary checking for Left and Right
+    playerLeft = std::max(0.0, playerLeft); // Respect 0 Minimum
+    playerRight = std::min(static_cast<double>(cols - 1), playerRight); // Respect cols - 1 Maximum
+
     // remove collision sprites from player space
     for (int j = playerLeft; j <= playerRight; j++)
     {


### PR DESCRIPTION
This commit fixes an error, where a for loop in the `construct` method for the CaveLevel did not respect the boundaries of a vector it was mutating.