### PR TITLE
Reconstruct Levels upon completion of all Levels

### DIFF
--- a/data/LeaderBoards.txt
+++ b/data/LeaderBoards.txt
@@ -1,3 +1,2 @@
 Space Runner High Scores
 Name		Score
-

--- a/headers/window.h
+++ b/headers/window.h
@@ -12,7 +12,7 @@
 
 #ifndef CONTENT_HEIGHT
 #define CONTENT_HEIGHT (GAMEBOARD_WINDOW_HEIGHT - 2 - 1) // Extra -1 to account for Score
-#endif // !CONTENT_HEIGHT
+#endif                                                   // !CONTENT_HEIGHT
 
 #ifndef CONTENT_WIDTH
 #define CONTENT_WIDTH (GAMEBOARD_WINDOW_WIDTH - 2)

--- a/lib/asteroid.cpp
+++ b/lib/asteroid.cpp
@@ -4,7 +4,7 @@
 void AsteroidLevel::construct()
 {
     int minHeight = 2, minWidth = 2, maxHeight = 5, maxWidth = 5;
-    int numAsteroids = 12, incrementor = screenHeight;
+    int numAsteroids = 8, incrementor = screenHeight;
     // Frame container
     // Add Asteroids to the frame
     deque<vector<char>> frame = deque<vector<char>>(screenHeight, vector<char>(cols, NULL_SPRITE));
@@ -50,7 +50,7 @@ void AsteroidLevel::construct()
         }
 
         // Increase difficulty by increasing the number of asteroids per frame
-        numAsteroids += 4;
+        numAsteroids += 2;
     }
 }
 

--- a/lib/gameEnvironment.cpp
+++ b/lib/gameEnvironment.cpp
@@ -17,7 +17,7 @@ GameEnvironment::GameEnvironment(int rows, int cols, int levelRows)
     AsteroidLevel *asteroidLevel = new AsteroidLevel(levelRows, width, height);
     CaveLevel *caveLevel = new CaveLevel(levelRows, width, height);
     CityLevel *cityLevel = new CityLevel(levelRows, width, height);
-    
+
     levels.push_back(caveLevel);
     levels.push_back(cityLevel);
     levels.push_back(asteroidLevel);
@@ -41,7 +41,13 @@ vector<char> GameEnvironment::nextRow()
     // If there's no more content available, nothing can be seeded
     if (level == nullptr || (!levelAvailable() && !level->rowAvailable()))
     {
-        return emptyRow;
+        levelIndex = 0;
+        transitionRows = matrix.rows();
+
+        for (LevelBuilder *level : levels)
+        {
+            level->reconstruct();
+        }
     }
     // Advance to the next level, if the current level is complete
     if (!level->rowAvailable() && !transitionRows)


### PR DESCRIPTION
This commit changes the GameEnvironment to reconstruct all the levels after the levels have been completed. This makes the game endless until a player collides with an object.